### PR TITLE
Changes for resolving xml entities.

### DIFF
--- a/Questor.Modules/Lookup/Settings.cs
+++ b/Questor.Modules/Lookup/Settings.cs
@@ -23,6 +23,7 @@ namespace Questor.Modules.Lookup
     using Questor.Modules.Caching;
     using Questor.Modules.Logging;
     using Questor.Modules.States;
+    using System.Xml;
 
     public class Settings
     {
@@ -980,7 +981,12 @@ namespace Questor.Modules.Lookup
             else //if the settings file exists - load the characters settings XML
             {
                 Settings.Instance.CharacterXMLExists = true;
-                XElement xml = XDocument.Load(Settings.Instance.SettingsPath).Root;
+                XElement xml;
+                using (var reader = new XmlTextReader(Settings.Instance.SettingsPath))
+                {
+                    reader.EntityHandling = EntityHandling.ExpandEntities;
+                    xml = XDocument.Load(reader).Root;
+                }
                 if (xml == null)
                 {
                     Logging.Log("Settings", "unable to find [" + Settings.Instance.SettingsPath +


### PR DESCRIPTION
You can have now one common config and set specific params for each toon.
Or you can use several configs like before.

Now this is right pull request. I tested it. Example:
Specific toon file:

``` xml
<?xml version="1.0" encoding="utf-8" ?>
<!DOCTYPE settings[
    <!ENTITY autostart "true">
    <!ENTITY x "1630">
    <!ENTITY y "10">
    <!ENTITY shipname "Mighty Tengu">
    <!ENTITY commonFile SYSTEM "file://C:\Program Files (x86)\InnerSpace\.NET Programs\common.xml">
]>
<settings>
&commonFile;
</settings>
```

Common.xml:

``` xml
    <!-- Auto start when Questor is loaded -->
    <autoStart>&autostart;</autoStart>

    <!-- X Position of Questor Window -->
    <windowXPosition>&x;</windowXPosition>

    <!-- Y Position of Questor Window -->
    <windowYPosition>&y;</windowYPosition>

    <!-- Faction specific fittings listed here -->
    <factionfittings>
        <factionfitting faction="Default" fitting="&shipname;" />
    </factionfittings>

    <!-- Ship used for combat missions, empty means current ship -->
    <combatShipName>&shipname;</combatShipName>
<!-- all other settings -->
```

Unfortunately, you must specify an absolute path to included file, but it is an URI and you can place this file to dropbox, for example.
And, please notice that root element should be in specific file, while common file does not contain it.
