### PR TITLE
* Fixes for changes in DirectEve v1.330.4904.26383

### DIFF
--- a/Questor.Modules/Activities/Traveler.cs
+++ b/Questor.Modules/Activities/Traveler.cs
@@ -30,7 +30,7 @@ namespace Questor.Modules.Activities
         //private static DateTime _nextSetEVENavDestination = DateTime.MinValue;
         //private static DateTime _nextGetDestinationPath = DateTime.MinValue;
 
-        private static List<long> _destinationRoute;
+        private static List<int> _destinationRoute;
         public static DirectLocation _location;
         private static IEnumerable<DirectBookmark> myHomeBookmarks;
         private static string _locationName;

--- a/Questor.Modules/Caching/Cache.cs
+++ b/Questor.Modules/Caching/Cache.cs
@@ -2448,7 +2448,7 @@ namespace Questor.Modules.Caching
                 // Find the first waypoint
                 if (DirectEve.Navigation.GetDestinationPath() != null && DirectEve.Navigation.GetDestinationPath().Count > 0)
                 {
-                    List<long> currentPath = DirectEve.Navigation.GetDestinationPath();
+                    List<int> currentPath = DirectEve.Navigation.GetDestinationPath();
                     if (currentPath == null || !currentPath.Any()) return false;
                     if (currentPath[0] == 0) return false; //No destination set - prevents exception if somehow we have got an invalid destination
 

--- a/Questor.Modules/Caching/EntityCache.cs
+++ b/Questor.Modules/Caching/EntityCache.cs
@@ -1344,7 +1344,7 @@ namespace Questor.Modules.Caching
             if (_directEntity != null && DateTime.UtcNow > Cache.Instance.NextApproachAction)
             {
                 Cache.Instance.NextApproachAction = DateTime.UtcNow.AddSeconds(Time.Instance.ApproachDelay_seconds);
-                _directEntity.Approach(range);
+                _directEntity.KeepAtRange(range);
             }
         }
 

--- a/Questor/Behaviors/CombatHelperBehavior.cs
+++ b/Questor/Behaviors/CombatHelperBehavior.cs
@@ -489,7 +489,7 @@ namespace Questor.Behaviors
 
                 case CombatHelperBehaviorState.Traveler:
                     Cache.Instance.OpenWrecks = false;
-                    List<long> destination = Cache.Instance.DirectEve.Navigation.GetDestinationPath();
+                    List<int> destination = Cache.Instance.DirectEve.Navigation.GetDestinationPath();
                     if (destination == null || destination.Count == 0)
                     {
                         // happens if autopilot is not set and this QuestorState is chosen manually

--- a/Questor/Behaviors/CombatMissionsBehavior.cs
+++ b/Questor/Behaviors/CombatMissionsBehavior.cs
@@ -1344,7 +1344,7 @@ namespace Questor.Behaviors
 
                 case CombatMissionsBehaviorState.Traveler:
                     Cache.Instance.OpenWrecks = false;
-                    List<long> destination = Cache.Instance.DirectEve.Navigation.GetDestinationPath();
+                    List<int> destination = Cache.Instance.DirectEve.Navigation.GetDestinationPath();
                     if (destination == null || destination.Count == 0)
                     {
                         // happens if autopilot is not set and this QuestorState is chosen manually

--- a/Questor/Behaviors/DebugBehavior.cs
+++ b/Questor/Behaviors/DebugBehavior.cs
@@ -454,7 +454,7 @@ namespace Questor.Behaviors
 
                 case DebugBehaviorState.Traveler:
                     Cache.Instance.OpenWrecks = false;
-                    List<long> destination = Cache.Instance.DirectEve.Navigation.GetDestinationPath();
+                    List<int> destination = Cache.Instance.DirectEve.Navigation.GetDestinationPath();
                     if (destination == null || destination.Count == 0)
                     {
                         // happens if autopilot is not set and this QuestorState is chosen manually

--- a/Questor/Behaviors/DebugHangarsBehavior.cs
+++ b/Questor/Behaviors/DebugHangarsBehavior.cs
@@ -451,7 +451,7 @@ namespace Questor.Behaviors
 
                 case DebugHangarsBehaviorState.Traveler:
                     Cache.Instance.OpenWrecks = false;
-                    List<long> destination = Cache.Instance.DirectEve.Navigation.GetDestinationPath();
+                    List<int> destination = Cache.Instance.DirectEve.Navigation.GetDestinationPath();
                     if (destination == null || destination.Count == 0)
                     {
                         // happens if autopilot is not set and this QuestorState is chosen manually

--- a/Questor/Behaviors/DirectionalScannerBehavior.cs
+++ b/Questor/Behaviors/DirectionalScannerBehavior.cs
@@ -286,7 +286,7 @@ namespace Questor.Behaviors
 
                 case DirectionalScannerBehaviorState.Traveler:
                     Cache.Instance.OpenWrecks = false;
-                    List<long> destination = Cache.Instance.DirectEve.Navigation.GetDestinationPath();
+                    List<int> destination = Cache.Instance.DirectEve.Navigation.GetDestinationPath();
                     if (destination == null || destination.Count == 0)
                     {
                         // happens if autopilot is not set and this QuestorState is chosen manually


### PR DESCRIPTION
``` C#
List<long> destination = Cache.Instance.DirectEve.Navigation.GetDestinationPath()
```

to

``` C#
List<int> destination = Cache.Instance.DirectEve.Navigation.GetDestinationPath()
```

and 

``` C#
_directEntity.Approach();
```

to

``` C#
_directEntity.KeepAtRange(range);
```

coz DirectEve now does not support Approach with arguments
